### PR TITLE
feat: add support for fixtures

### DIFF
--- a/examples/google_benchmark/fixture_bench.hpp
+++ b/examples/google_benchmark/fixture_bench.hpp
@@ -1,0 +1,65 @@
+// See docs:
+// https://github.com/google/benchmark/blob/main/docs/user_guide.md#fixtures
+
+#ifndef FIXTURE_BENCH_HPP
+#define FIXTURE_BENCH_HPP
+
+
+#include <benchmark/benchmark.h>
+
+namespace example_namespace {
+
+class MyFixture : public benchmark::Fixture {
+public:
+  void SetUp(::benchmark::State &state) {}
+
+  void TearDown(::benchmark::State &state) {}
+};
+BENCHMARK_F(MyFixture, FooTest)(benchmark::State &st) {
+  for (auto _ : st) {
+  }
+}
+BENCHMARK_DEFINE_F(MyFixture, BarTest)(benchmark::State &st) {
+  for (auto _ : st) {
+  }
+}
+BENCHMARK_REGISTER_F(MyFixture, BarTest);
+
+//
+//
+
+template <typename T> class MyTemplatedFixture : public benchmark::Fixture {};
+BENCHMARK_TEMPLATE_F(MyTemplatedFixture, IntTest, int)(benchmark::State &st) {
+  for (auto _ : st) {
+  }
+}
+BENCHMARK_TEMPLATE_DEFINE_F(MyTemplatedFixture, DoubleTest,
+                            double)(benchmark::State &st) {
+  for (auto _ : st) {
+  }
+}
+BENCHMARK_REGISTER_F(MyTemplatedFixture, DoubleTest);
+
+//
+//
+
+template <typename T> class MyTemplate1 : public benchmark::Fixture {};
+BENCHMARK_TEMPLATE1_DEFINE_F(MyTemplate1, TestA, int)(benchmark::State &st) {
+  for (auto _ : st) {
+  }
+}
+BENCHMARK_REGISTER_F(MyTemplate1, TestA);
+
+//
+//
+
+template <typename T, typename U> class MyTemplate2 : public benchmark::Fixture {};
+BENCHMARK_TEMPLATE2_DEFINE_F(MyTemplate2, TestB, int, double)(benchmark::State &st) {
+  for (auto _ : st) {
+  }
+}
+BENCHMARK_REGISTER_F(MyTemplate2, TestB);
+
+}
+
+#endif

--- a/examples/google_benchmark/main.cpp
+++ b/examples/google_benchmark/main.cpp
@@ -1,3 +1,4 @@
+#include "fixture_bench.hpp"
 #include "template_bench.hpp"
 #include <benchmark/benchmark.h>
 #include <cstring>


### PR DESCRIPTION
Normal output: 
```
MyFixture/FooTest                                   0.000 ns        0.000 ns   1000000000000
MyFixture/BarTest                                   0.000 ns        0.000 ns   1000000000000
MyTemplatedFixture<int>/IntTest                     0.000 ns        0.000 ns   1000000000000
MyTemplatedFixture<double>/DoubleTest               0.000 ns        0.000 ns   1000000000000
MyTemplate1<int>/TestA                              0.000 ns        0.000 ns   1000000000000
MyTemplate2<int,double>/TestB                       0.000 ns        0.000 ns   1000000000000
```

Output with instrumentation enabled:
```
Checked: examples/google_benchmark/fixture_bench.hpp::example_namespace::MyFixture[FooTest]
Checked: examples/google_benchmark/fixture_bench.hpp::example_namespace::MyFixture[BarTest]
Checked: examples/google_benchmark/fixture_bench.hpp::example_namespace::MyTemplatedFixture[IntTest, int]
Checked: examples/google_benchmark/fixture_bench.hpp::example_namespace::MyTemplatedFixture[DoubleTest, double]
Checked: examples/google_benchmark/fixture_bench.hpp::example_namespace::MyTemplate1[TestA, int]
Checked: examples/google_benchmark/fixture_bench.hpp::example_namespace::MyTemplate2[TestB, int, double]
```

Minor detail: Should the format be `MyFixture[TestA]` or `TestA[MyFixture]`. Both make sense imo.