### PR TITLE
fix(bazel): expose codspeed_mode flag

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -67,6 +67,7 @@ string_flag(
         "instrumentation",
         "walltime",
     ],
+    visibility = ["//visibility:public"],
 )
 
 config_setting(


### PR DESCRIPTION
My root module depends transitively on codspeed through an intermediary. It does not depend on it directly with a `bazel_dep` in MODULE.bazel.

Thus I cannot set `--@codspeed//core:codspeed_mode` on my command line - in bzlmod that's a strict visibility violation. The intermediary should provide an alias to set the mode. This requires the flag to be public.