### PR TITLE
chore: bump instrument-hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -90,7 +94,6 @@ jobs:
         with:
           mode: ${{ matrix.codspeed-mode }}
           run: examples/google_benchmark_cmake/build/benchmark_example
-          token: ${{ secrets.CODSPEED_TOKEN }}
 
   bazel-integration-tests:
     strategy:
@@ -130,7 +133,6 @@ jobs:
         with:
           mode: ${{ matrix.codspeed-mode }}
           run: bazel run //examples/google_benchmark_bazel:my_benchmark --@codspeed_core//:codspeed_mode=${{ matrix.codspeed-mode }} --@codspeed_core//:strict_warnings=on
-          token: ${{ secrets.CODSPEED_TOKEN }}
 
   cmake-build:
     strategy:

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,7 +15,7 @@ include(FetchContent)
 FetchContent_Declare(
     instrument_hooks_repo
     GIT_REPOSITORY https://github.com/CodSpeedHQ/instrument-hooks
-    GIT_TAG b1e401a4d031ad308edb22ed59a52253a1ebe924
+    GIT_TAG 89fb72a076ec71c9eca6eee9bca98bada4b4dfb4
 )
 FetchContent_MakeAvailable(instrument_hooks_repo)
 FetchContent_GetProperties(instrument_hooks_repo)


### PR DESCRIPTION
- Fixes an edge case where remaining commands aren't cleared from the buffer
- Removes 128B allocations that aren't from the benchmark
