### PR TITLE
fix: exclude paused sections from instrumentation measurement

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -15,7 +15,7 @@ include(FetchContent)
 FetchContent_Declare(
     instrument_hooks_repo
     GIT_REPOSITORY https://github.com/CodSpeedHQ/instrument-hooks
-    GIT_TAG b9ddb5bc654b2e6fa13eb18efcd3a45e7ecda0bb
+    GIT_TAG 1ec92c8c9db59db2d0adc37f47d003d3db4e1c64
 )
 FetchContent_MakeAvailable(instrument_hooks_repo)
 FetchContent_GetProperties(instrument_hooks_repo)

--- a/core/include/measurement.hpp
+++ b/core/include/measurement.hpp
@@ -56,6 +56,12 @@ inline void measurement_set_metadata() {
   instrument_hooks_write_environment(g_hooks, getpid());
 }
 
+#ifdef CODSPEED_ANALYSIS
+// inline (C++17) so every translation unit shares one definition; a static
+// would give each TU its own copy and silently desync the toggle parity.
+inline bool measurement_collecting = true;
+#endif
+
 ALWAYS_INLINE void measurement_start() {
   instrument_hooks_start_benchmark_inline(g_hooks);
 }
@@ -87,5 +93,24 @@ ALWAYS_INLINE void measurement_add_benchmark_timestamps(uint64_t start,
   measurement_add_marker(MARKER_TYPE_BENCHMARK_START, start);
   measurement_add_marker(MARKER_TYPE_BENCHMARK_END, end);
 }
+
+#ifdef CODSPEED_ANALYSIS
+ALWAYS_INLINE void measurement_pause_timing() {
+  if (measurement_collecting) {
+    callgrind_toggle_collect();
+    measurement_collecting = false;
+  }
+}
+
+ALWAYS_INLINE void measurement_resume_timing() {
+  if (!measurement_collecting) {
+    callgrind_toggle_collect();
+    measurement_collecting = true;
+  }
+}
+#else
+ALWAYS_INLINE void measurement_pause_timing() {}
+ALWAYS_INLINE void measurement_resume_timing() {}
+#endif
 
 #endif  // MEASUREMENT_H

--- a/google_benchmark/src/benchmark.cc
+++ b/google_benchmark/src/benchmark.cc
@@ -19,9 +19,7 @@
 #include "codspeed.h"
 #include "internal_macros.h"
 
-#ifdef CODSPEED_WALLTIME
 #include "measurement.hpp"
-#endif
 
 #ifndef BENCHMARK_OS_WINDOWS
 #if !defined(BENCHMARK_OS_FUCHSIA) && !defined(BENCHMARK_OS_QURT)
@@ -272,6 +270,7 @@ void State::PauseTiming() {
 #ifdef CODSPEED_WALLTIME
   uint64_t pause_timestamp = measurement_current_timestamp();
 #endif
+  measurement_pause_timing();
 
   // Add in time accumulated so far
   BM_CHECK(started_ && !finished_ && !skipped());
@@ -310,6 +309,7 @@ void State::ResumeTiming() {
   BM_CHECK(resume_timestamp_ == 0);
   resume_timestamp_ = measurement_current_timestamp();
 #endif
+  measurement_resume_timing();
 }
 
 void State::SkipWithMessage(const std::string& msg) {
@@ -324,6 +324,7 @@ void State::SkipWithMessage(const std::string& msg) {
   total_iterations_ = 0;
   if (timer_->running()) {
     timer_->StopTimer();
+    measurement_pause_timing();
   }
 }
 
@@ -339,6 +340,7 @@ void State::SkipWithError(const std::string& msg) {
   total_iterations_ = 0;
   if (timer_->running()) {
     timer_->StopTimer();
+    measurement_pause_timing();
   }
 }
 


### PR DESCRIPTION
PauseTiming/ResumeTiming now stop/start Callgrind instrumentation in
CODSPEED_ANALYSIS mode, ensuring setup/teardown code is not included
in benchmark measurements.

Depends on https://github.com/CodSpeedHQ/instrument-hooks/pull/29
