### PR TITLE
Cod 2092 collect toolchain information alongside run

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -96,6 +96,25 @@ target_link_libraries(codspeed PRIVATE instrument_hooks)
 # Version
 add_compile_definitions(CODSPEED_VERSION="${CODSPEED_VERSION}")
 
+# Collect compiler toolchain information for environment reporting
+execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} --version
+    OUTPUT_VARIABLE CODSPEED_CXX_COMPILER_FULL_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+)
+# Extract first line only
+if(CODSPEED_CXX_COMPILER_FULL_VERSION)
+    string(REGEX REPLACE "\n.*" "" CODSPEED_CXX_COMPILER_FULL_VERSION "${CODSPEED_CXX_COMPILER_FULL_VERSION}")
+endif()
+
+target_compile_definitions(codspeed PRIVATE
+    CODSPEED_CXX_COMPILER_ID="${CMAKE_CXX_COMPILER_ID}"
+    CODSPEED_CXX_COMPILER_VERSION="${CMAKE_CXX_COMPILER_VERSION}"
+    CODSPEED_CXX_COMPILER_FULL_VERSION="${CODSPEED_CXX_COMPILER_FULL_VERSION}"
+    CODSPEED_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+)
+
 # Specify the include directories for users of the library
 target_include_directories(
     codspeed

--- a/core/include/measurement.hpp
+++ b/core/include/measurement.hpp
@@ -35,6 +35,21 @@ inline bool measurement_is_instrumented() {
 inline void measurement_set_metadata() {
   std::string version = get_version();
   instrument_hooks_set_integration(g_hooks, "codspeed-cpp", version.c_str());
+
+  // Report C++ toolchain information
+#ifdef CODSPEED_CXX_COMPILER_ID
+  instrument_hooks_set_toolchain("cpp", "compiler_id", CODSPEED_CXX_COMPILER_ID);
+#endif
+#ifdef CODSPEED_CXX_COMPILER_VERSION
+  instrument_hooks_set_toolchain("cpp", "version", CODSPEED_CXX_COMPILER_VERSION);
+#endif
+#ifdef CODSPEED_CXX_COMPILER_FULL_VERSION
+  instrument_hooks_set_toolchain("cpp", "build", CODSPEED_CXX_COMPILER_FULL_VERSION);
+#endif
+#ifdef CODSPEED_BUILD_TYPE
+  instrument_hooks_set_toolchain("cpp", "build_type", CODSPEED_BUILD_TYPE);
+#endif
+  instrument_hooks_write_environment();
 }
 
 ALWAYS_INLINE void measurement_start() {
@@ -54,9 +69,9 @@ ALWAYS_INLINE uint64_t measurement_current_timestamp() {
   return instrument_hooks_current_timestamp();
 }
 
-ALWAYS_INLINE int8_t measurement_add_marker(uint8_t marker_type,
-                                            uint64_t timestamp) {
-  auto pid = getpid();
+ALWAYS_INLINE uint8_t measurement_add_marker(uint8_t marker_type,
+                                             uint64_t timestamp) {
+  auto pid = static_cast<uint32_t>(getpid());
   return instrument_hooks_add_marker(g_hooks, pid, marker_type, timestamp);
 }
 


### PR DESCRIPTION
Outputs in `${CODSPEED_PROFILE_FOLDER}/environment-<pid>.json`
```json environment.json
{
  "toolchains": {
    "cpp": {
      "compiler_id": "Clang",
      "version": "19.1.7",
      "build": "clang version 19.1.7",
      "build_type": "RelWithDebInfo"
    }
  }
}
```

```json
{
  "toolchains": {
    "cpp": {
      "compiler_id": "GNU",
      "version": "14.3.0",
      "build": "g++ (GCC) 14.3.0",
      "build_type": "RelWithDebInfo"
    }
  }
}
```